### PR TITLE
Account for other single-host topologies

### DIFF
--- a/internal/cloud/gke.go
+++ b/internal/cloud/gke.go
@@ -467,7 +467,8 @@ func (g *GKE) nodePoolForPod(p *corev1.Pod) (*containerv1beta1.NodePool, error) 
 
 	// placement policy is only valid in GKE for non "1t" shapes
 	placementPolicy := &containerv1beta1.PlacementPolicy{}
-	if !strings.HasSuffix(machineType, "1t") {
+	singleHost := strings.HasSuffix(machineType, "1t") || strings.HasSuffix(machineType, "8t")
+	if !singleHost {
 		placementPolicy.TpuTopology = tpuTopo
 		placementPolicy.Type = "COMPACT"
 	}


### PR DESCRIPTION
ct6e-standard-8t is also single host, and should not have a placementPolicy