### PR TITLE
Determine if configuration is a single or sub host configuration more resiliently

### DIFF
--- a/internal/cloud/gke.go
+++ b/internal/cloud/gke.go
@@ -468,8 +468,7 @@ func (g *GKE) nodePoolForPod(p *corev1.Pod) (*containerv1beta1.NodePool, error) 
 
 	// placement policy is only valid in GKE for non "1t" shapes
 	placementPolicy := &containerv1beta1.PlacementPolicy{}
-	singleHost := strings.HasSuffix(machineType, "1t") || strings.HasSuffix(machineType, "8t")
-	if !singleHost {
+	if nodeCount != 1 {
 		placementPolicy.TpuTopology = tpuTopo
 		placementPolicy.Type = "COMPACT"
 	}

--- a/internal/cloud/gke_test.go
+++ b/internal/cloud/gke_test.go
@@ -514,6 +514,71 @@ func TestNodePoolForPod(t *testing.T) {
 			},
 		},
 		{
+			desc: "2x2 topology should have no placement policy",
+			pod: podBuild{
+				selector: map[string]string{
+					"cloud.google.com/gke-tpu-accelerator": "tpu-v6e-slice",
+					"cloud.google.com/gke-tpu-topology":    "2x2",
+				},
+				tpuResource: "4",
+			},
+			want: &container.NodePool{
+				Config: &container.NodeConfig{
+					Labels: map[string]string{
+						"google.com/nodepool-manager":                 "tpu-provisioner",
+						"google.com/tpu-provisioner-jobset-name":      "jobset-test",
+						"google.com/tpu-provisioner-jobset-namespace": "default",
+						"google.com/tpu-provisioner-parent-kind":      "job",
+						"google.com/tpu-provisioner-parent-name":      "jobset-test-job-1-0",
+						"google.com/tpu-provisioner-parent-namespace": "default",
+					},
+					MachineType:            "ct6e-standard-4t",
+					ShieldedInstanceConfig: &container.ShieldedInstanceConfig{EnableIntegrityMonitoring: true},
+				},
+				InitialNodeCount:  1,
+				Locations:         []string{""},
+				Management:        &container.NodeManagement{AutoRepair: true, AutoUpgrade: false},
+				MaxPodsConstraint: &container.MaxPodsConstraint{MaxPodsPerNode: 15},
+				PlacementPolicy:   &container.PlacementPolicy{},
+				Name:              "jobset-test-rando",
+				UpgradeSettings:   &container.UpgradeSettings{MaxSurge: 1},
+			},
+		},
+		{
+			desc: "4x4 topology should have placement policy",
+			pod: podBuild{
+				selector: map[string]string{
+					"cloud.google.com/gke-tpu-accelerator": "tpu-v6e-slice",
+					"cloud.google.com/gke-tpu-topology":    "4x4",
+				},
+				tpuResource: "16",
+			},
+			want: &container.NodePool{
+				Config: &container.NodeConfig{
+					Labels: map[string]string{
+						"google.com/nodepool-manager":                 "tpu-provisioner",
+						"google.com/tpu-provisioner-jobset-name":      "jobset-test",
+						"google.com/tpu-provisioner-jobset-namespace": "default",
+						"google.com/tpu-provisioner-parent-kind":      "job",
+						"google.com/tpu-provisioner-parent-name":      "jobset-test-job-1-0",
+						"google.com/tpu-provisioner-parent-namespace": "default",
+					},
+					MachineType:            "ct6e-standard-16t",
+					ShieldedInstanceConfig: &container.ShieldedInstanceConfig{EnableIntegrityMonitoring: true},
+				},
+				InitialNodeCount:  4,
+				Locations:         []string{""},
+				Management:        &container.NodeManagement{AutoRepair: true, AutoUpgrade: false},
+				MaxPodsConstraint: &container.MaxPodsConstraint{MaxPodsPerNode: 15},
+				PlacementPolicy: &container.PlacementPolicy{
+					TpuTopology: "4x4",
+					Type:        "COMPACT",
+				},
+				Name:            "jobset-test-rando",
+				UpgradeSettings: &container.UpgradeSettings{MaxSurge: 1},
+			},
+		},
+		{
 			desc: "spot",
 			pod: podBuild{
 				additionalSelector: map[string]string{

--- a/internal/cloud/gke_test.go
+++ b/internal/cloud/gke_test.go
@@ -237,6 +237,23 @@ func Test_tpuTopologyToNodeCount(t *testing.T) {
 			count: 1,
 		},
 		{
+			accel: "tpu-v6e-slice",
+			topo:  "2x2",
+			count: 1,
+		},
+		// Note: There is a possible configuraiton where 2x4 is attached to 1
+		// VMs, however this is not being taken into account by tpuTopologyToNodeCount.
+		{
+			accel: "tpu-v6e-slice",
+			topo:  "2x4",
+			count: 2,
+		},
+		{
+			accel: "tpu-v6e-slice",
+			topo:  "4x4",
+			count: 4,
+		},
+		{
 			accel: "not-an-accel",
 			topo:  "2x4",
 			err:   true,
@@ -342,6 +359,11 @@ func Test_tpuMachineType(t *testing.T) {
 			accel:       "tpu-v5p-slice",
 			tpuRequest:  4,
 			machineType: "ct5p-hightpu-4t",
+		},
+		{
+			accel:       "tpu-v6e-slice",
+			tpuRequest:  4,
+			machineType: "ct6e-standard-4t",
 		},
 		{
 			accel:      "not-an-accel",


### PR DESCRIPTION
Updated the code that determines if a `placementPolicy` should be used to use `tpuTopologyToNodeCount` which consistently determines node count compared to simply checking the suffix of `machineType`. Simply checking the suffix is not sufficient as some single/sub-host configurations use the same `machineType` as multi-host configurations.

Additionally some unit tests for v6e configurations were added.