### PR TITLE
single host placement policy fixes

### DIFF
--- a/examples/trillium-jobset-spot-1.yaml
+++ b/examples/trillium-jobset-spot-1.yaml
@@ -1,7 +1,7 @@
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
-  name: ironwood-jobset-spot
+  name: test-v6e-1-jobset
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool # 1:1 job replica to node pool assignment
 spec:
@@ -11,19 +11,20 @@ spec:
   - name: workers
     replicas: 1 # set to number of node pools
     template:
-      spec:
+      spec: 
         backoffLimit: 0
         # completions and parallelism should be the number of cores divided by 8
         # (e.g. 4 for a v4-32)
-        completions: 2
-        parallelism: 2
+        completions: 1
+        parallelism: 1
         template:
           spec:
             restartPolicy: Never
             nodeSelector:
-              cloud.google.com/gke-tpu-accelerator: tpu7x
-              cloud.google.com/gke-tpu-topology: 2x2x2
+              cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+              cloud.google.com/gke-tpu-topology: 1x1
               cloud.google.com/gke-spot: "true"
+              abc: xyz
             tolerations:
             - key: cloud.google.com/gke-spot
               operator: Equal
@@ -32,7 +33,7 @@ spec:
             containers:
             - name: tpu-job
               image: python:3.8
-              ports:
+              ports: 
               - containerPort: 8471 # Default port using which TPU VMs communicate
               securityContext:
                 privileged: true
@@ -41,6 +42,6 @@ spec:
               - "600"
               resources:
                 requests:
-                  google.com/tpu: 4
+                  google.com/tpu: 1
                 limits:
-                  google.com/tpu: 4
+                  google.com/tpu: 1

--- a/examples/trillium-jobset-spot-16.yaml
+++ b/examples/trillium-jobset-spot-16.yaml
@@ -1,7 +1,7 @@
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
-  name: ironwood-jobset-spot
+  name: test-v6e-16-jobset
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool # 1:1 job replica to node pool assignment
 spec:
@@ -11,7 +11,7 @@ spec:
   - name: workers
     replicas: 1 # set to number of node pools
     template:
-      spec:
+      spec: 
         backoffLimit: 0
         # completions and parallelism should be the number of cores divided by 8
         # (e.g. 4 for a v4-32)
@@ -21,9 +21,10 @@ spec:
           spec:
             restartPolicy: Never
             nodeSelector:
-              cloud.google.com/gke-tpu-accelerator: tpu7x
-              cloud.google.com/gke-tpu-topology: 2x2x2
+              cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+              cloud.google.com/gke-tpu-topology: 4x4
               cloud.google.com/gke-spot: "true"
+              abc: xyz
             tolerations:
             - key: cloud.google.com/gke-spot
               operator: Equal
@@ -32,7 +33,7 @@ spec:
             containers:
             - name: tpu-job
               image: python:3.8
-              ports:
+              ports: 
               - containerPort: 8471 # Default port using which TPU VMs communicate
               securityContext:
                 privileged: true

--- a/examples/trillium-jobset-spot-4.yaml
+++ b/examples/trillium-jobset-spot-4.yaml
@@ -1,0 +1,47 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: test-v6e-4-jobset
+  annotations:
+    alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool # 1:1 job replica to node pool assignment
+spec:
+  failurePolicy:
+    maxRestarts: 3
+  replicatedJobs:
+  - name: workers
+    replicas: 1 # set to number of node pools
+    template:
+      spec: 
+        backoffLimit: 0
+        # completions and parallelism should be the number of cores divided by 8
+        # (e.g. 4 for a v4-32)
+        completions: 1
+        parallelism: 1
+        template:
+          spec:
+            restartPolicy: Never
+            nodeSelector:
+              cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+              cloud.google.com/gke-tpu-topology: 2x2
+              cloud.google.com/gke-spot: "true"
+              abc: xyz
+            tolerations:
+            - key: cloud.google.com/gke-spot
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+            containers:
+            - name: tpu-job
+              image: python:3.8
+              ports: 
+              - containerPort: 8471 # Default port using which TPU VMs communicate
+              securityContext:
+                privileged: true
+              command:
+              - "sleep"
+              - "600"
+              resources:
+                requests:
+                  google.com/tpu: 4
+                limits:
+                  google.com/tpu: 4

--- a/examples/trillium-jobset-spot-8-4t.yaml
+++ b/examples/trillium-jobset-spot-8-4t.yaml
@@ -1,7 +1,7 @@
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
-  name: ironwood-jobset-spot
+  name: test-v6e-8-4t-jobset
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool # 1:1 job replica to node pool assignment
 spec:
@@ -11,19 +11,20 @@ spec:
   - name: workers
     replicas: 1 # set to number of node pools
     template:
-      spec:
+      spec: 
         backoffLimit: 0
         # completions and parallelism should be the number of cores divided by 8
         # (e.g. 4 for a v4-32)
-        completions: 2
-        parallelism: 2
+        completions: 1
+        parallelism: 1
         template:
           spec:
             restartPolicy: Never
             nodeSelector:
-              cloud.google.com/gke-tpu-accelerator: tpu7x
-              cloud.google.com/gke-tpu-topology: 2x2x2
+              cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+              cloud.google.com/gke-tpu-topology: 2x4
               cloud.google.com/gke-spot: "true"
+              abc: xyz
             tolerations:
             - key: cloud.google.com/gke-spot
               operator: Equal
@@ -32,7 +33,7 @@ spec:
             containers:
             - name: tpu-job
               image: python:3.8
-              ports:
+              ports: 
               - containerPort: 8471 # Default port using which TPU VMs communicate
               securityContext:
                 privileged: true

--- a/examples/trillium-jobset-spot-8-8t.yaml
+++ b/examples/trillium-jobset-spot-8-8t.yaml
@@ -1,7 +1,7 @@
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
-  name: ironwood-jobset-spot
+  name: test-v6e-8-8t-jobset
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool # 1:1 job replica to node pool assignment
 spec:
@@ -11,19 +11,20 @@ spec:
   - name: workers
     replicas: 1 # set to number of node pools
     template:
-      spec:
+      spec: 
         backoffLimit: 0
         # completions and parallelism should be the number of cores divided by 8
         # (e.g. 4 for a v4-32)
-        completions: 2
-        parallelism: 2
+        completions: 1
+        parallelism: 1
         template:
           spec:
             restartPolicy: Never
             nodeSelector:
-              cloud.google.com/gke-tpu-accelerator: tpu7x
-              cloud.google.com/gke-tpu-topology: 2x2x2
+              cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+              cloud.google.com/gke-tpu-topology: 2x4
               cloud.google.com/gke-spot: "true"
+              abc: xyz
             tolerations:
             - key: cloud.google.com/gke-spot
               operator: Equal
@@ -32,7 +33,7 @@ spec:
             containers:
             - name: tpu-job
               image: python:3.8
-              ports:
+              ports: 
               - containerPort: 8471 # Default port using which TPU VMs communicate
               securityContext:
                 privileged: true
@@ -41,6 +42,6 @@ spec:
               - "600"
               resources:
                 requests:
-                  google.com/tpu: 4
+                  google.com/tpu: 8
                 limits:
-                  google.com/tpu: 4
+                  google.com/tpu: 8

--- a/internal/cloud/gke.go
+++ b/internal/cloud/gke.go
@@ -473,7 +473,9 @@ func (g *GKE) nodePoolForPod(p *corev1.Pod) (*containerv1beta1.NodePool, error) 
 		placementPolicy.PolicyName = fmt.Sprintf("tpu-provisioner-%v", tpuTopo)
 	} else {
 		// For non-v7x, placement policies are only used for multi-host topologies
-		singleHost := strings.HasSuffix(machineType, "1t") || machineType == "ct6e-standard-8t" || machineType == "ct6e-standard-4t"
+		singleHost := strings.HasSuffix(machineType, "1t") ||
+			machineType == "ct6e-standard-8t" ||
+			(machineType == "ct6e-standard-4t" && nodeCount == 1)
 		if !singleHost {
 			placementPolicy.TpuTopology = tpuTopo
 			placementPolicy.Type = "COMPACT"

--- a/internal/cloud/gke.go
+++ b/internal/cloud/gke.go
@@ -472,8 +472,8 @@ func (g *GKE) nodePoolForPod(p *corev1.Pod) (*containerv1beta1.NodePool, error) 
 		// TPU v7x slices must use workload policy
 		placementPolicy.PolicyName = fmt.Sprintf("tpu-provisioner-%v", tpuTopo)
 	} else {
-
-		singleHost := strings.HasSuffix(machineType, "1t") || strings.HasSuffix(machineType, "8t")
+		// For non-v7x, placement policies are only used for multi-host topologies
+		singleHost := strings.HasSuffix(machineType, "1t") || machineType == "ct6e-standard-8t"
 		if !singleHost {
 			placementPolicy.TpuTopology = tpuTopo
 			placementPolicy.Type = "COMPACT"

--- a/internal/cloud/gke.go
+++ b/internal/cloud/gke.go
@@ -473,7 +473,7 @@ func (g *GKE) nodePoolForPod(p *corev1.Pod) (*containerv1beta1.NodePool, error) 
 		placementPolicy.PolicyName = fmt.Sprintf("tpu-provisioner-%v", tpuTopo)
 	} else {
 		// For non-v7x, placement policies are only used for multi-host topologies
-		singleHost := strings.HasSuffix(machineType, "1t") || machineType == "ct6e-standard-8t"
+		singleHost := strings.HasSuffix(machineType, "1t") || machineType == "ct6e-standard-8t" || machineType == "ct6e-standard-4t"
 		if !singleHost {
 			placementPolicy.TpuTopology = tpuTopo
 			placementPolicy.Type = "COMPACT"

--- a/internal/cloud/gke_test.go
+++ b/internal/cloud/gke_test.go
@@ -244,7 +244,7 @@ func Test_tpuTopologyToNodeCount(t *testing.T) {
 		{
 			accel: "tpu-v6e-slice",
 			topo:  "2x4",
-			count: 1,
+			count: 2,
 		},
 		{
 			accel: "tpu-v6e-slice",

--- a/internal/cloud/gke_test.go
+++ b/internal/cloud/gke_test.go
@@ -364,6 +364,11 @@ func Test_tpuMachineType(t *testing.T) {
 			machineType: "ct6e-standard-4t",
 		},
 		{
+			accel:       "tpu-v6e-slice",
+			tpuRequest:  8,
+			machineType: "ct6e-standard-8t",
+		},
+		{
 			accel:      "not-an-accel",
 			tpuRequest: 4,
 			err:        true,


### PR DESCRIPTION
Fix single host placement policy issue for v6e 8t and 4t single host machine types in 2x4 and 2x2 topology configurations

Tested on all topologies specified in the example jobsets included here.

pulls in tests from this PR, but doesn't use node count to determine single host status because this is not a 1-1 mapping: https://github.com/ai-on-gke/tpu-provisioner/pull/6